### PR TITLE
Use body instead of ids when querying _mtermvectors

### DIFF
--- a/inelastic.py
+++ b/inelastic.py
@@ -80,7 +80,11 @@ class InvertedIndex:
             for hit in search['hits']['hits']:
                 val = hit['_source'][id_field] if id_field else hit['_id']
                 hit_ids[hit['_id']] = val
-                hit_docs[hit['_id']] = {"_id": hit['_id'], "_index": hit['_index'], "_type": hit['_type']}
+                hit_docs[hit['_id']] = {
+                    "_id": hit['_id'],
+                    "_index": hit['_index'],
+                    "_type": hit['_type']
+                }
 
             resp = es.mtermvectors(body={"docs": list(hit_docs.values())},
                                    fields=field)

--- a/inelastic.py
+++ b/inelastic.py
@@ -75,11 +75,14 @@ class InvertedIndex:
 
         while search['hits']['hits']:
             hit_ids = {}
+            hit_docs = {}
+
             for hit in search['hits']['hits']:
                 val = hit['_source'][id_field] if id_field else hit['_id']
                 hit_ids[hit['_id']] = val
+                hit_docs[hit['_id']] = {"_id": hit['_id'], "_index": hit['_index'], "_type": hit['_type']}
 
-            resp = es.mtermvectors(ids=list(hit_ids.keys()), index=index,
+            resp = es.mtermvectors(body={"docs": list(hit_docs.values())},
                                    fields=field)
 
             errors = 0


### PR DESCRIPTION
Here, we are also populating the `_index` field from the initial lookup. This means that this script will also work when using index patterns like: `logs-2019-09-*`.

In the previous version, the index was explicitly set from the input - this was causing an `index not found` error when using an index pattern.